### PR TITLE
Upper Chart Interactivity Fixes #34

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,6 +119,8 @@ app.layout = html.Div([
             ], className="app-main--year-container app-main--filter-panel")
         ], className="app-main--panel-left"),
         html.Div([
+                html.P("Click on a bar to select a movie",
+                className="app-main--highlight"),
             html.Div([
                 html.Iframe(sandbox="allow-scripts",
                             id="chart",

--- a/assets/main.css
+++ b/assets/main.css
@@ -116,3 +116,11 @@ P {
     color: white;
     padding: 10px;
 }
+
+.app-main--highlight {
+    color: red;
+    text-align: center;
+    margin-top: 2em;
+    font-weight: bold;
+    font-size: 20px;
+}

--- a/src/lower_chart.py
+++ b/src/lower_chart.py
@@ -47,18 +47,20 @@ def create_lower_chart(df, pts, genres, ratings, year_from, year_to):
     top_10["rank"] = top_10.index + 1
 
     p1 = alt.Chart(df).mark_circle(opacity=0.4).encode(
-
         alt.X("IMDB_Rating:Q", title="IMDB Rating"),
         alt.Y("Rotten_Tomatoes_Rating:Q", title="Rotten Tomatoes Rating"),
-        alt.Tooltip(["IMDB_Rating", "Rotten_Tomatoes_Rating"])).interactive()
+        alt.Tooltip(["IMDB_Rating", "Rotten_Tomatoes_Rating"]))
 
     p2 = alt.Chart(top_10).mark_circle(size=200,
                                        opacity=1).encode(
         alt.X("IMDB_Rating:Q"),
         alt.Y("Rotten_Tomatoes_Rating:Q"),
-        
+        color=alt.condition(
+            pts,
+            alt.Color("Title:O", scale=alt.Scale(range=["#d1720d", "#d1720d"]), legend=None),
+            alt.ColorValue("grey")),        
         tooltip=alt.Tooltip(["IMDB_Rating", "Rotten_Tomatoes_Rating", "Title"])
-    ).interactive()
+    )
 
     combined_scatter = (p1 + p2).properties(
         title="Movie Ratings")

--- a/src/lower_chart.py
+++ b/src/lower_chart.py
@@ -56,10 +56,7 @@ def create_lower_chart(df, pts, genres, ratings, year_from, year_to):
                                        opacity=1).encode(
         alt.X("IMDB_Rating:Q"),
         alt.Y("Rotten_Tomatoes_Rating:Q"),
-        color=alt.condition(
-            pts,
-            alt.Color("Title:O", scale=alt.Scale(scheme="set1"), legend=None),
-            alt.ColorValue("grey")),
+        
         tooltip=alt.Tooltip(["IMDB_Rating", "Rotten_Tomatoes_Rating", "Title"])
     ).interactive()
 

--- a/src/upper_chart.py
+++ b/src/upper_chart.py
@@ -77,8 +77,8 @@ def create_upper_chart(df, pts, genres, ratings, year_from, year_to):
         alt.X("gross_revenue_per_million:Q", title="Gross Revenue (millions of USD)"),
         color=alt.condition(
             pts,
-            alt.Color("Title:O", scale=alt.Scale(scheme="set1"), legend=None),
+            alt.Color("Title:O", scale=alt.Scale(range=["#d1720d", "#d1720d"]), legend=None),
             alt.ColorValue("grey"))
     ).add_selection(pts)
 
-    return top_us_gross_chart.interactive()
+    return top_us_gross_chart


### PR DESCRIPTION
Upper Chart Interactivity Fixes #34
Can we use a single colour for upper chart? - Implemented
Can we start off with no movies selected (all grey)? - Implemented
Add instructions so user knows to select a movie. - Implemented
Remove interactivity from both charts - - Implemented
Perhaps only show one single large dot for movie selected since we only have one colour now and it'll be hard to match movies with dots - Highlights only one selected movie. But marker size of all top 10 movies are the same in the scatterplot